### PR TITLE
Throw an error if pattern is not string or regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,22 +11,19 @@ Matchex.prototype.use = function(pattern, cb, options = { caseInsentive: false }
     regex = new RegExp(pattern, options.caseInsentive ? 'i' : '');
   } else if (isRegExp(pattern)) {
     regex = pattern;
+  } else {
+    throw new Error('Pattern must be a string or a regular expression');
   }
 
-  if (this.matchers.has(regex)) {
-    this.matchers.get(regex).push(cb);
-  }
-  this.matchers.set(regex, [cb]);
+  this.matchers.set(regex, cb);
   return this.matchers.get(regex);
 };
 
 Matchex.prototype.run = function(text) {
-  for (let [regex, cbs] of this.matchers.entries()) {
+  for (let [regex, cb] of this.matchers.entries()) {
     const match  = text.match(regex);
     if (match) {
-      cbs.forEach(cb => {
-        cb.apply(null, match);
-      });
+      cb.apply(null, match);
     }
   }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -9,70 +9,62 @@ describe('Test functionality of matchex', () => {
     matchex = new Matchex();
   });
 
-  it('Should match a simple pattern', done => {
+  it('Should match a simple pattern', () => {
     matchex.use('This is a (.*)', (all, word) => {
       expect(all).to.equal('This is a test');
       expect(word).to.equal('test');
-      done();
     });
     matchex.run('This is a test');
   });
 
-  it('Should all for duplicate patterns to match', done => {
-    const allDone = after(2, done);
-
+  it('Should all for duplicate patterns to match', () => {
     matchex.use('This is a (.*)', (all, word) => {
       expect(all).to.equal('This is a test');
       expect(word).to.equal('test');
-      allDone();
     });
 
     matchex.use('This is a (.*)', (all, word) => {
       expect(all).to.equal('This is a test');
       expect(word).to.equal('test');
-      allDone();
     });
 
     matchex.run('This is a test');
   });
 
-  it('Should match multiple groups', done => {
+  it('Should match multiple groups', () => {
     matchex.use('(.*) is (.*) (.*)', (all, first, second, third) => {
       expect(all).to.equal('This is a test');
       expect(first).to.equal('This');
       expect(second).to.equal('a');
       expect(third).to.equal('test');
-      done();
     });
 
     matchex.run('This is a test');
   });
 
-  it('Should be able to be make matches case insensitive', done => {
-    const allDone = after(4, done);
-
+  it('Should be able to be make matches case insensitive', () => {
     matchex.use('THIS IS A (.*)', (all, word) => {
       expect(word).to.equal('test');
-      allDone();
     }, { caseInsentive: true });
 
     matchex.use('This is a (.*)', (all, word) => {
       expect(word).to.equal('test');
-      allDone();
     }, { caseInsentive: true });
 
     matchex.run('This is a test');
     matchex.run('THIS IS A test');
   });
 
-  it('Should work with a regex literal', done => {
+  it('Should work with a regex literal', () => {
     matchex.use(/Testing testing (.*)\s(.*)\s(.*)/, (all, first, second, third) => {
       expect(first).to.equal('1');
       expect(second).to.equal('2');
       expect(third).to.equal('3');
-      done();
     });
     matchex.run('Testing testing 1 2 3');
   });
 
+  it('Should throw an error if passed something other than a string or RegExp', () => {
+    expect(() => matchex.use(1, function() {})).to.throw(Error);
+  });
 });


### PR DESCRIPTION
Also, no longer collecting an array of callbacks. A new regex will be
created for each pattern, which makes the cbs.has check return false
every time. Simply creating a new matcher is far easier than trying to
loop through all of the entries and comparing `toString` results to find
an existing matcher.